### PR TITLE
Added reference to time.h allowing to build with time_t in prototypes

### DIFF
--- a/src/hacklib.h
+++ b/src/hacklib.h
@@ -5,6 +5,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <time.h>
 
 bool digit(char);
 bool letter(char);


### PR DESCRIPTION
Line `long yyyymmdd(time_t);` throws an error as it doesn't recognize time_t without including time.h